### PR TITLE
release-schema.json: add numbers and forReduction properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2023-04-05
 
-* Add the `forReduction` and `numbers` fields to `SelectionCriterion`. The `numbers` field reuses the `CriterionNumber` definition from the [Award criteria breakdown](https://extensions.open-contracting.org/en/extensions/awardCriteria/master/) extension.
+* Add `forReduction` and `numbers` fields to `SelectionCriterion`. The `numbers` field reuses the `CriterionNumber` definition from the [Award criteria breakdown](https://extensions.open-contracting.org/en/extensions/awardCriteria/master/) extension.
 
 ### 2020-07-13
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2023-04-05
 
-* Add `forReduction` field and `numbers` object to `SelectionCriterion`.
+* Add the `forReduction` and `numbers` fields to `SelectionCriterion`. The `numbers` field reuses the `CriterionNumber` definition from the [Award criteria breakdown](https://extensions.open-contracting.org/en/extensions/awardCriteria/master/) extension.
 
 ### 2020-07-13
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2020-07-13
 
-* Add the `appliesTo` field.
+* Add `appliesTo` field.
 
 ### 2020-04-24
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 Adds an object to describe the criteria to qualify candidates to participate in a contracting process.
 
+If you are using the [Lots extension](https://extensions.open-contracting.org/en/extensions/lots/master/), [follow its guidance](https://extensions.open-contracting.org/en/extensions/lots/master/#usage) on whether to use `tender.lots` fields or `tender` fields.
+
 ## Legal context
 
-In the European Union, this extension's fields correspond to [eForms BG-702 (Selection Criteria)](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
+In the European Union, this extension's fields correspond to [eForms BG-702 (Selection Criteria) and BG-72 (Selection Criteria Second Stage Invite Number)](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/). For correspondences to eForms fields, see [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/).
 
 ## Examples
+
+### Tender
+
+A tender with a single selection criterion.
 
 ```json
 {
@@ -20,18 +26,45 @@ In the European Union, this extension's fields correspond to [eForms BG-702 (Sel
           "appliesTo": [
             "supplier",
             "subcontractor"
-          ]
-        },
-        {
-          "description": "<Description of the criterion>",
-          "minimum": "<Minimum value or level of compliance>",
-          "type": "economic",
-          "appliesTo": [
-            "supplier"
-          ]
+          ],
+          "numbers": [
+              {
+                "number": "40",
+                "threshold": "minimumScore"
+              }
+            ]
         }
       ]
     }
+  }
+}
+```
+
+### Lot
+
+A tender with a single lot where the selection criterion only applies for selecting candidates to be invited to the second stage of the procedure.
+
+```json
+{
+  "tender": {
+    "lots": [
+      {
+        "id": "LOT-0001",
+        "selectionCriteria": {
+          "criteria": {
+            "description": "A description of the criteria",
+            "type": "suitability",
+            "forReduction": true,
+            "numbers": [
+              {
+                "number": "30",
+                "weight": "percentageExact"
+              }
+            ]
+          }
+        }
+      }
+    ]
   }
 }
 ```
@@ -42,9 +75,13 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ## Changelog
 
+### 2023-04-05
+
+* Add `forReduction` field and `numbers` object to `SelectionCriterion`.
+
 ### 2020-07-13
 
-* Add the `appliesTo` field
+* Add the `appliesTo` field.
 
 ### 2020-04-24
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ If you are using the [Lots extension](https://extensions.open-contracting.org/en
 
 ## Legal context
 
-In the European Union, this extension's fields correspond to [eForms BG-702 (Selection Criteria) and BG-72 (Selection Criteria Second Stage Invite Number)](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/). For correspondences to eForms fields, see [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/).
+In the European Union, this extension's fields correspond to [eForms BG-702 (Selection Criteria) and BG-72 (Selection Criteria Second Stage Invite Number)](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/). For correspondences to eForms fields, see [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
 
 ## Examples
 
 ### Tender
 
-A tender with a single selection criterion.
+Potential suppliers and subcontractors must demonstrate a minimum of 10 years experience on similar projects.
 
 ```json
 {
@@ -20,18 +20,12 @@ A tender with a single selection criterion.
     "selectionCriteria": {
       "criteria": [
         {
-          "description": "<Description of the criterion>",
-          "minimum": "<Minimum value or level of compliance>",
+          "description": "Minimum number of years of experience on similar projects",
+          "minimum": "10",
           "type": "technical",
           "appliesTo": [
             "supplier",
             "subcontractor"
-          ],
-          "numbers": [
-            {
-              "number": 40,
-              "threshold": "minimumScore"
-            }
           ]
         }
       ]
@@ -42,7 +36,7 @@ A tender with a single selection criterion.
 
 ### Lot
 
-A tender with a single lot where the selection criterion only applies for selecting candidates to be invited to the second stage of the procedure.
+A tender with a single lot where the selection criterion only applies for selecting candidates to be invited to the second stage of the procedure. The candidates will be selected only if the rate of their turnover over the value of the contract is at least 2.
 
 ```json
 {
@@ -53,13 +47,13 @@ A tender with a single lot where the selection criterion only applies for select
         "selectionCriteria": {
           "criteria": [
             {
-              "description": "A description of the criteria",
-              "type": "suitability",
+              "description": "Turnover over contract value rate",
+              "type": "economic",
               "forReduction": true,
               "numbers": [
                 {
-                  "number": 30,
-                  "weight": "percentageExact"
+                  "number": 2,
+                  "threshold": "minimumScore"
                 }
               ]
             }

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ A tender with a single selection criterion.
             "subcontractor"
           ],
           "numbers": [
-              {
-                "number": "40",
-                "threshold": "minimumScore"
-              }
-            ]
+            {
+              "number": 40,
+              "threshold": "minimumScore"
+            }
+          ]
         }
       ]
     }
@@ -51,17 +51,19 @@ A tender with a single lot where the selection criterion only applies for select
       {
         "id": "LOT-0001",
         "selectionCriteria": {
-          "criteria": {
-            "description": "A description of the criteria",
-            "type": "suitability",
-            "forReduction": true,
-            "numbers": [
-              {
-                "number": "30",
-                "weight": "percentageExact"
-              }
-            ]
-          }
+          "criteria": [
+            {
+              "description": "A description of the criteria",
+              "type": "suitability",
+              "forReduction": true,
+              "numbers": [
+                {
+                  "number": 30,
+                  "weight": "percentageExact"
+                }
+              ]
+            }
+          ]
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2023-04-05
 
-* Add `forReduction` and `numbers` fields to `SelectionCriterion`. The `numbers` field reuses the `CriterionNumber` definition from the [Award criteria breakdown](https://extensions.open-contracting.org/en/extensions/awardCriteria/master/) extension.
+* Add `forReduction` and `numbers` fields to the `SelectionCriterion` object. The `numbers` field reuses the `CriterionNumber` definition from the [Award criteria breakdown](https://extensions.open-contracting.org/en/extensions/awardCriteria/master/) extension.
 
 ### 2020-07-13
 

--- a/extension.json
+++ b/extension.json
@@ -23,6 +23,7 @@
     "email": "data@open-contracting.org"
   },
   "testDependencies": [
-    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json",
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_awardCriteria_extension/master/extension.json"
   ]
 }

--- a/extension.json
+++ b/extension.json
@@ -21,7 +21,7 @@
   "contactPoint": {
     "name": "Open Contracting Partnership",
     "email": "data@open-contracting.org"
-  }, 
+  },
   "dependencies": [
     "https://raw.githubusercontent.com/open-contracting-extensions/ocds_awardCriteria_extension/master/extension.json"
   ],

--- a/extension.json
+++ b/extension.json
@@ -21,9 +21,11 @@
   "contactPoint": {
     "name": "Open Contracting Partnership",
     "email": "data@open-contracting.org"
-  },
-  "testDependencies": [
-    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json",
+  }, 
+  "dependencies": [
     "https://raw.githubusercontent.com/open-contracting-extensions/ocds_awardCriteria_extension/master/extension.json"
+  ],
+  "testDependencies": [
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
   ]
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -104,6 +104,25 @@
           "openCodelist": false,
           "uniqueItems": true,
           "minItems": 1
+        },
+        "forReduction": {
+          "title": "For reduction?",
+          "description": "A true/false field to indicate if the criteria (or criterion) will (only) be used to select the candidates to be invited for the second stage of the procedure (if a maximum number of candidates was set).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "numbers": {
+          "title": "Selection criterion numbers",
+          "description": "Information about the numbers linked to the selection criteria.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AwardCriterionNumber"
+          },
+          "wholeListMerge": true,
+          "uniqueItems": true,
+          "minItems": 1
         }
       },
       "minProperties": 1

--- a/release-schema.json
+++ b/release-schema.json
@@ -118,7 +118,7 @@
           "description": "Information about the numbers linked to the selection criteria.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AwardCriterionNumber"
+            "$ref": "#/definitions/CriterionNumber"
           },
           "wholeListMerge": true,
           "uniqueItems": true,

--- a/release-schema.json
+++ b/release-schema.json
@@ -107,15 +107,15 @@
         },
         "forReduction": {
           "title": "For reduction?",
-          "description": "A true/false field to indicate if the criteria (or criterion) will (only) be used to select the candidates to be invited for the second stage of the procedure (if a maximum number of candidates was set).",
+          "description": "Whether the criterion is used to select the potential suppliers to be invited to the second stage of the contracting process, if the number of invitations is limited.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "numbers": {
-          "title": "Selection criterion numbers",
-          "description": "Information about the numbers linked to the selection criteria.",
+          "title": "Numbers",
+          "description": "Numbers linked to the criterion.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/CriterionNumber"


### PR DESCRIPTION
I've used the `AwardCriterionNumber` object from the [award criteria](https://extensions.open-contracting.org/en/extensions/awardCriteria/master/schema/#awardcriterionnumber) extension here to add a `numbers` object. This has however added an additional field that we don't need for eForms, `numbers.fixed`. But even if eForms doesn't need it it seems like a field that's okay to have in the extension as another jurisdiction may have a need for it? 