### PR TITLE
add verificationMethod field

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Potential suppliers and subcontractors must demonstrate a minimum of 10 years ex
 
 ### Lot
 
-A tender with a single lot where the selection criterion only applies for selecting candidates to be invited to the second stage of the procedure. The candidates will be selected only if the rate of their turnover over the value of the contract is at least 2. The procuring entity will use annual accounts from the previous 2 financial years to verify the candidates turnover.
+A tender with a single lot where the selection criterion only applies for selecting candidates to be invited to the second stage of the procedure. The candidates will be selected only if the rate of their turnover over the value of the contract is at least 2. The procuring entity will use annual accounts from the previous two financial years to verify the candidates' turnover.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Potential suppliers and subcontractors must demonstrate a minimum of 10 years ex
 
 ### Lot
 
-A tender with a single lot where the selection criterion only applies for selecting candidates to be invited to the second stage of the procedure. The candidates will be selected only if the rate of their turnover over the value of the contract is at least 2.
+A tender with a single lot where the selection criterion only applies for selecting candidates to be invited to the second stage of the procedure. The candidates will be selected only if the rate of their turnover over the value of the contract is at least 2. The procuring entity will use annual accounts from the previous 2 financial years to verify the candidates turnover.
 
 ```json
 {
@@ -61,7 +61,8 @@ A tender with a single lot where the selection criterion only applies for select
                   "number": 2,
                   "threshold": "minimumScore"
                 }
-              ]
+              ],
+              "verificationMethod": "Annual accounts from previous 2 financial years."
             }
           ]
         }
@@ -76,6 +77,10 @@ A tender with a single lot where the selection criterion only applies for select
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2024-01-25
+
+* Add `verificationMethod` field to the `SelectionCriterion` object.
 
 ### 2023-04-05
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -4,7 +4,7 @@
       "properties": {
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "Information about the conditions for participation in a procedure.",
+          "description": "The minimum requirements for potential suppliers to participate in the contracting process. Selection criteria ensure that a potential supplier has the legal and financial capacities and the technical and professional abilities to perform the contract.",
           "$ref": "#/definitions/SelectionCriteria"
         }
       }
@@ -36,7 +36,7 @@
         },
         "description": {
           "title": "Description",
-          "description": "The description of the criteria used to select the economic operators who will be allowed to bid.",
+          "description": "The description of the criteria.",
           "type": [
             "string",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -126,7 +126,7 @@
         },
         "verificationMethod": {
           "title": "Verification method",
-          "description": "The methods the buyer or procuring entity will use to verify the potential supplier has satisfied the criterion.",
+          "description": "The methods the buyer or procuring entity uses to verify the potential supplier satisfies the criterion.",
           "type": [
             "string",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -123,6 +123,15 @@
           "wholeListMerge": true,
           "uniqueItems": true,
           "minItems": 1
+        },
+        "verificationMethod": {
+          "title": "Verification method",
+          "description": "The methods the buyer or procuring entity will use to verify the potential supplier has satisfied the criterion.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
         }
       },
       "minProperties": 1


### PR DESCRIPTION
closes https://github.com/open-contracting/ocds-extensions/issues/218
closes https://github.com/open-contracting/ocds-extensions/issues/221

giving an overwrite error when compared to 1.2 which has had `selectionCriteria` added to it as a single string field rather than an object. This is partially under discussion in https://github.com/open-contracting/standard/issues/1607